### PR TITLE
chore: remove hardcoded development override in service idler

### DIFF
--- a/handlers/idler/service.go
+++ b/handlers/idler/service.go
@@ -61,7 +61,7 @@ func (h *Idler) ServiceIdler() {
 		environmentAutoIdle, ok2 := namespace.ObjectMeta.Labels[h.Selectors.NamespaceSelectorsLabels.EnvironmentIdling]
 		environmentType, ok3 := namespace.ObjectMeta.Labels[h.Selectors.NamespaceSelectorsLabels.EnvironmentType]
 		if ok1 && ok2 && ok3 {
-			if environmentType == "development" && environmentAutoIdle == "1" && projectAutoIdle == "1" {
+			if environmentAutoIdle == "1" && projectAutoIdle == "1" {
 				envOpLog := opLog.WithValues("namespace", namespace.ObjectMeta.Name).
 					WithValues("project", namespace.ObjectMeta.Labels[h.Selectors.NamespaceSelectorsLabels.ProjectName]).
 					WithValues("environment", namespace.ObjectMeta.Labels[h.Selectors.NamespaceSelectorsLabels.EnvironmentName]).


### PR DESCRIPTION
Just a simple thing to remove the hardcoded development environment override since namespace selectors are used to determine which namespaces are evaluated.

It still uses the idling labels to determine what namespaces can be idled which come from lagoon