### PR TITLE
feat: add metrics for cli idling events

### DIFF
--- a/handlers/idler/cli-kubernetes.go
+++ b/handlers/idler/cli-kubernetes.go
@@ -136,6 +136,7 @@ func (h *Idler) kubernetesCLI(ctx context.Context, opLog logr.Logger, namespace 
 									} else {
 										opLog.Info(fmt.Sprintf("Deployment %s scaled to 0", deployment.ObjectMeta.Name))
 									}
+									cliIdleEvents.Inc()
 								} else {
 									opLog.Info(fmt.Sprintf("Deployment %s would be scaled to 0", deployment.ObjectMeta.Name))
 								}

--- a/handlers/idler/metrics.go
+++ b/handlers/idler/metrics.go
@@ -6,8 +6,12 @@ import (
 )
 
 var (
-	idleEvents = promauto.NewCounter(prometheus.CounterOpts{
+	serviceIdleEvents = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "aergia_idling_events",
-		Help: "The total number of events that aergia has processed to idle environments",
+		Help: "The total number of service idling events that aergia has processed to idle environments",
+	})
+	cliIdleEvents = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "aergia_cli_idling_events",
+		Help: "The total number of cli idling events that aergia has processed to idle environments",
 	})
 )

--- a/handlers/idler/service-kubernetes.go
+++ b/handlers/idler/service-kubernetes.go
@@ -276,7 +276,7 @@ func (h *Idler) patchIngress(ctx context.Context, opLog logr.Logger, namespace c
 					},
 				},
 			})
-			idleEvents.Inc()
+			serviceIdleEvents.Inc()
 			if err := h.Client.Patch(ctx, namespaceCopy, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
 				return fmt.Errorf(fmt.Sprintf("Error patching namespace %s", namespace.Name))
 			}


### PR DESCRIPTION
Just a quick one to also capture metrics for events when CLI pods are idled