### PR TITLE
Configure application security in CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"
+- package-ecosystem: docker
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    docker:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"
+- package-ecosystem: gomod
+  commit-message:
+    prefix: chore
+    include: scope
+  directory: /
+  schedule:
+    interval: monthly
+  groups:
+    gomod:
+      patterns:
+      - "*"
+      update-types:
+      - "minor"
+      - "patch"

--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -1,0 +1,17 @@
+# https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md
+allow-licenses:
+- 'Apache-2.0'
+- 'BSD-2-Clause'
+- 'BSD-2-Clause-FreeBSD'
+- 'BSD-3-Clause'
+- 'ISC'
+- 'MIT'
+- 'PostgreSQL'
+- 'Python-2.0'
+- 'X11'
+- 'Zlib'
+
+allow-dependencies-licenses:
+# this action is GPL-3 but it is only used in CI
+# https://github.com/actions/dependency-review-action/issues/530#issuecomment-1638291806
+- pkg:githubactions/vladopajic/go-test-coverage@bcd064e5ceef1ccec5441519eb054263b6a44787

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -9,9 +9,17 @@ on:
   pull_request:
     branches:
       - 'main'
-
+permissions: {}
 jobs:
   docker:
+    permissions:
+      # checkout
+      contents: read
+      # image push
+      packages: write
+      # required by attest-build-provenance
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       -
@@ -48,9 +56,24 @@ jobs:
       -
         name: Build and push
         uses: docker/build-push-action@v5
+        id: build-and-push
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest dockerhub image
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        with:
+          subject-digest: ${{steps.build-and-push.outputs.digest}}
+          subject-name: index.docker.io/${{ github.repository_owner }}/aergia
+          push-to-registry: true
+
+      - name: Attest ghcr image
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        with:
+          subject-digest: ${{steps.build-and-push.outputs.digest}}
+          subject-name: ghcr.io/${{ github.repository_owner }}/aergia
+          push-to-registry: true

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,27 @@
+name: coverage
+on:
+  push:
+    branches:
+    - main
+permissions: {}
+jobs:
+  coverage:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      with:
+        go-version: stable
+    - name: Calculate coverage
+      run: |
+        go test -v -covermode=atomic -coverprofile=cover.out -coverpkg=./... ./...
+    - name: Generage coverage badge
+      uses: vladopajic/go-test-coverage@937b863f06595080198d555b7ed3aa474ae5199c # v2.14.1
+      with:
+        profile: cover.out
+        local-prefix: github.com/${{ github.repository }}
+        git-token: ${{ secrets.GITHUB_TOKEN }}
+        # orphan branch for storing badges
+        git-branch: badges

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,16 @@
+name: dependency review
+on:
+  pull_request:
+    branches:
+    - main
+permissions: {}
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
+      with:
+        config-file: .github/dependency-review-config.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,28 @@
+name: lint
+on:
+  pull_request:
+    branches:
+    - main
+permissions: {}
+jobs:
+  lint-go:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      with:
+        go-version: stable
+    - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+      with:
+        args: --timeout=180s --enable gocritic
+  lint-actions:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: docker://rhysd/actionlint:1.7.0@sha256:601d6faeefa07683a4a79f756f430a1850b34d575d734b1d1324692202bf312e # v1.7.0
+      with:
+        args: -color

--- a/.github/workflows/ossf-analysis.yaml
+++ b/.github/workflows/ossf-analysis.yaml
@@ -1,0 +1,31 @@
+name: OSSF scorecard
+on:
+  push:
+    branches:
+    - main
+permissions: {}
+jobs:
+  ossf-scorecard-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed if using Code scanning alerts
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Run analysis
+      uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+      with:
+        results_file: results.sarif
+        results_format: sarif
+        # Publish the results for public repositories to enable scorecard badges. For more details, see
+        # https://github.com/ossf/scorecard-action#publishing-results.
+        # For private repositories, `publish_results` will automatically be set to `false`, regardless
+        # of the value entered here.
+        publish_results: true
+    - name: Upload SARIF results to code scanning
+      uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+      with:
+        sarif_file: results.sarif

--- a/.github/workflows/tag-to-release.yaml
+++ b/.github/workflows/tag-to-release.yaml
@@ -1,0 +1,37 @@
+name: tag to release
+on:
+  push:
+    tags:
+    - v*
+permissions: {}
+jobs:
+  release:
+    permissions:
+      # create release
+      contents: write
+      # required by attest-build-provenance
+      id-token: write
+      attestations: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+    - name: Create release
+      run: |
+        gh release create "${{ github.ref_name }}" --verify-tag --generate-notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Attach SBOM to release in SPDX JSON format
+      # https://docs.github.com/en/rest/dependency-graph/sboms?apiVersion=2022-11-28
+      run: |
+        gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{ github.repository }}/dependency-graph/sbom > sbom.spdx.json
+        gh release upload "${{ github.ref_name }}" sbom.spdx.json
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+      with:
+        subject-path: sbom.spdx.json

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,5 @@
+version: "2"
+linters:
+  exclusions:
+    presets:
+    - std-error-handling

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Aergia
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uselagoon/aergia-controller/badge)](https://securityscorecards.dev/viewer/?uri=github.com/uselagoon/aergia-controller)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10427/badge)](https://www.bestpractices.dev/projects/10427)
+
 > In Greek mythology, Aergia is the personification of sloth, idleness, indolence and laziness
 
 Aergia is a controller that can be used to scale deployments from zero when a request is made to an ingress with a zero scaled deployment.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uselagoon/aergia-controller/badge)](https://securityscorecards.dev/viewer/?uri=github.com/uselagoon/aergia-controller)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10427/badge)](https://www.bestpractices.dev/projects/10427)
+[![coverage](https://raw.githubusercontent.com/uselagoon/aergia-controller/badges/.badges/main/coverage.svg)](https://github.com/uselagoon/aergia-controller/actions/workflows/coverage.yaml)
 
 > In Greek mythology, Aergia is the personification of sloth, idleness, indolence and laziness
 


### PR DESCRIPTION
Partially addresses: #32

Once this is merged the remaining config changes can be made to the repo and #32 closed.