### PR TITLE
fix: response content type fix

### DIFF
--- a/internal/handlers/unidler/handler.go
+++ b/internal/handlers/unidler/handler.go
@@ -39,6 +39,11 @@ func (h *Unidler) ingressHandler(path string) func(http.ResponseWriter, *http.Re
 			format = "text/html"
 		}
 
+		// Browser may send a list of accepted formats, but we only want the first reported content type for the response
+		if strings.Contains(format, ",") {
+			format = strings.Split(format, ",")[0]
+		}
+
 		w.Header().Set(ContentType, format)
 		w.Header().Set(AergiaHeader, "true")
 		w.Header().Set(CacheControl, "private,no-store")


### PR DESCRIPTION
Starting 0.5.1 browser did not display unidler page correctly, both Firefox and Chrome tried to interpret landing page as xml. I added a `--debug` flag and it printed this content type from browser:

> Request for [environment] verfied: false from xff:[ip]; tcip:; ua: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:136.0) Gecko/20100101 Firefox/136.0, 	{"custom-default-backend": "request"}
> Serving custom error response for code 503 and format text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 from file /www/unidle.html	{"custom-default-backend": "request"}


Browser may send a list of accepted formats, but we only want the first reported content type for the response. I don't know which scenarios would return response other than `text/html`, but let's keep the logic (in case landing page contains non-html response and request if done via some cli tool).