### PR TITLE
chore: disable dockerhub image attestation

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -64,13 +64,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository_owner }}/aergia
-          push-to-registry: true
-
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         with:


### PR DESCRIPTION
Until dockerhub supports the OCI Referrers API, attestations attached to
images result in numerous noisy sha256-* tags. So disable dockerhub
image attestation for now.
