### PR TITLE
feat: Make response status code configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,7 +74,7 @@ func main() {
 	var verifiedUnidling bool
 	var verifiedSecret string
 
-	var defaultHTTPErrorCode int
+	var defaultHTTPResponseCode int
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -110,13 +110,13 @@ func main() {
 	flag.StringVar(&verifiedSecret, "verify-secret", "super-secret-string",
 		"The secret to use for verifying unidling requests.")
 	flag.IntVar(&unidlerHTTPPort, "unidler-port", 5000, "Port for the unidler service to listen on.")
-	flag.IntVar(&defaultHTTPErrorCode, "default-http-error-code", 404, "Default HTTP error code for ingress")
+	flag.IntVar(&defaultHTTPResponseCode, "default-http-response-code", 404, "Default HTTP response code.")
 	flag.Parse()
 
 	selectorsFile = variables.GetEnv("SELECTORS_YAML_FILE", selectorsFile)
 	verifiedUnidling = variables.GetEnvBool("VERIFIED_UNIDLING", verifiedUnidling)
 	verifiedSecret = variables.GetEnv("VERIFY_SECRET", verifiedSecret)
-	defaultHTTPErrorCode = variables.GetEnvInt("DEFAULT_HTTP_ERROR_CODE", defaultHTTPErrorCode)
+	defaultHTTPResponseCode = variables.GetEnvInt("DEFAULT_HTTP_RESPONSE_CODE", defaultHTTPResponseCode)
 
 	dryRun = variables.GetEnvBool("DRY_RUN", dryRun)
 
@@ -202,18 +202,18 @@ func main() {
 	allowedIPs, _ := unidler.ReadSliceFromFile("/lists/allowedips")
 	blockedIPs, _ := unidler.ReadSliceFromFile("/lists/blockedips")
 	u := &unidler.Unidler{
-		Client:               mgr.GetClient(),
-		Log:                  ctrl.Log.WithName("aergia-controller").WithName("Unidler"),
-		RefreshInterval:      refreshInterval,
-		Debug:                debug,
-		AllowedUserAgents:    allowedAgents,
-		BlockedUserAgents:    blockedAgents,
-		AllowedIPs:           allowedIPs,
-		BlockedIPs:           blockedIPs,
-		UnidlerHTTPPort:      unidlerHTTPPort,
-		VerifiedUnidling:     verifiedUnidling,
-		VerifiedSecret:       verifiedSecret,
-		DefaultHTTPErrorCode: defaultHTTPErrorCode,
+		Client:                  mgr.GetClient(),
+		Log:                     ctrl.Log.WithName("aergia-controller").WithName("Unidler"),
+		RefreshInterval:         refreshInterval,
+		Debug:                   debug,
+		AllowedUserAgents:       allowedAgents,
+		BlockedUserAgents:       blockedAgents,
+		AllowedIPs:              allowedIPs,
+		BlockedIPs:              blockedIPs,
+		UnidlerHTTPPort:         unidlerHTTPPort,
+		VerifiedUnidling:        verifiedUnidling,
+		VerifiedSecret:          verifiedSecret,
+		DefaultHTTPResponseCode: defaultHTTPResponseCode,
 	}
 
 	prometheusClient, err := prometheusapi.NewClient(prometheusapi.Config{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,6 +74,8 @@ func main() {
 	var verifiedUnidling bool
 	var verifiedSecret string
 
+	var defaultHTTPErrorCode int
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
@@ -108,11 +110,13 @@ func main() {
 	flag.StringVar(&verifiedSecret, "verify-secret", "super-secret-string",
 		"The secret to use for verifying unidling requests.")
 	flag.IntVar(&unidlerHTTPPort, "unidler-port", 5000, "Port for the unidler service to listen on.")
+	flag.IntVar(&defaultHTTPErrorCode, "default-http-error-code", 404, "Default HTTP error code for ingress")
 	flag.Parse()
 
 	selectorsFile = variables.GetEnv("SELECTORS_YAML_FILE", selectorsFile)
 	verifiedUnidling = variables.GetEnvBool("VERIFIED_UNIDLING", verifiedUnidling)
 	verifiedSecret = variables.GetEnv("VERIFY_SECRET", verifiedSecret)
+	defaultHTTPErrorCode = variables.GetEnvInt("DEFAULT_HTTP_ERROR_CODE", defaultHTTPErrorCode)
 
 	dryRun = variables.GetEnvBool("DRY_RUN", dryRun)
 
@@ -198,17 +202,18 @@ func main() {
 	allowedIPs, _ := unidler.ReadSliceFromFile("/lists/allowedips")
 	blockedIPs, _ := unidler.ReadSliceFromFile("/lists/blockedips")
 	u := &unidler.Unidler{
-		Client:            mgr.GetClient(),
-		Log:               ctrl.Log.WithName("aergia-controller").WithName("Unidler"),
-		RefreshInterval:   refreshInterval,
-		Debug:             debug,
-		AllowedUserAgents: allowedAgents,
-		BlockedUserAgents: blockedAgents,
-		AllowedIPs:        allowedIPs,
-		BlockedIPs:        blockedIPs,
-		UnidlerHTTPPort:   unidlerHTTPPort,
-		VerifiedUnidling:  verifiedUnidling,
-		VerifiedSecret:    verifiedSecret,
+		Client:               mgr.GetClient(),
+		Log:                  ctrl.Log.WithName("aergia-controller").WithName("Unidler"),
+		RefreshInterval:      refreshInterval,
+		Debug:                debug,
+		AllowedUserAgents:    allowedAgents,
+		BlockedUserAgents:    blockedAgents,
+		AllowedIPs:           allowedIPs,
+		BlockedIPs:           blockedIPs,
+		UnidlerHTTPPort:      unidlerHTTPPort,
+		VerifiedUnidling:     verifiedUnidling,
+		VerifiedSecret:       verifiedSecret,
+		DefaultHTTPErrorCode: defaultHTTPErrorCode,
 	}
 
 	prometheusClient, err := prometheusapi.NewClient(prometheusapi.Config{

--- a/internal/handlers/unidler/handler.go
+++ b/internal/handlers/unidler/handler.go
@@ -51,7 +51,7 @@ func (h *Unidler) ingressHandler(path string) func(http.ResponseWriter, *http.Re
 		errCode := r.Header.Get(CodeHeader)
 		code, err := strconv.Atoi(errCode)
 		if err != nil {
-			code = 404
+			code = h.DefaultHTTPErrorCode
 		}
 		w.WriteHeader(code)
 		ns := r.Header.Get(Namespace)

--- a/internal/handlers/unidler/handler.go
+++ b/internal/handlers/unidler/handler.go
@@ -51,7 +51,7 @@ func (h *Unidler) ingressHandler(path string) func(http.ResponseWriter, *http.Re
 		errCode := r.Header.Get(CodeHeader)
 		code, err := strconv.Atoi(errCode)
 		if err != nil {
-			code = h.DefaultHTTPErrorCode
+			code = h.DefaultHTTPResponseCode
 		}
 		w.WriteHeader(code)
 		ns := r.Header.Get(Namespace)

--- a/internal/handlers/unidler/unidler.go
+++ b/internal/handlers/unidler/unidler.go
@@ -33,18 +33,19 @@ const (
 
 // Unidler is the client structure for http handlers.
 type Unidler struct {
-	Client            ctrlClient.Client
-	Log               logr.Logger
-	RefreshInterval   int
-	UnidlerHTTPPort   int
-	Debug             bool
-	VerifiedUnidling  bool
-	VerifiedSecret    string
-	Locks             sync.Map
-	AllowedUserAgents []string
-	BlockedUserAgents []string
-	AllowedIPs        []string
-	BlockedIPs        []string
+	Client               ctrlClient.Client
+	Log                  logr.Logger
+	RefreshInterval      int
+	UnidlerHTTPPort      int
+	Debug                bool
+	VerifiedUnidling     bool
+	VerifiedSecret       string
+	Locks                sync.Map
+	AllowedUserAgents    []string
+	BlockedUserAgents    []string
+	AllowedIPs           []string
+	BlockedIPs           []string
+	DefaultHTTPErrorCode int
 }
 
 type pageData struct {

--- a/internal/handlers/unidler/unidler.go
+++ b/internal/handlers/unidler/unidler.go
@@ -33,19 +33,19 @@ const (
 
 // Unidler is the client structure for http handlers.
 type Unidler struct {
-	Client               ctrlClient.Client
-	Log                  logr.Logger
-	RefreshInterval      int
-	UnidlerHTTPPort      int
-	Debug                bool
-	VerifiedUnidling     bool
-	VerifiedSecret       string
-	Locks                sync.Map
-	AllowedUserAgents    []string
-	BlockedUserAgents    []string
-	AllowedIPs           []string
-	BlockedIPs           []string
-	DefaultHTTPErrorCode int
+	Client                  ctrlClient.Client
+	Log                     logr.Logger
+	RefreshInterval         int
+	UnidlerHTTPPort         int
+	Debug                   bool
+	VerifiedUnidling        bool
+	VerifiedSecret          string
+	Locks                   sync.Map
+	AllowedUserAgents       []string
+	BlockedUserAgents       []string
+	AllowedIPs              []string
+	BlockedIPs              []string
+	DefaultHTTPResponseCode int
 }
 
 type pageData struct {

--- a/test/e2e/e2e_suite.go
+++ b/test/e2e/e2e_suite.go
@@ -295,6 +295,14 @@ var _ = ginkgo.Describe("controller", ginkgo.Ordered, func() {
 			fmt.Printf("metrics: %s", string(output))
 			err = utils.CheckStringContainsStrings(string(output), metricLabels)
 			gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred())
+
+			// verify that 404 HTTP error is being returned for non-existing ingress
+			ginkgo.By("validating default HTTP error code")
+			runCmd = fmt.Sprintf(`curl -s -I http://non-existing-domain.%s.nip.io/`, kindIP)
+			output, _ = utils.RunCommonsCommand(namespace, runCmd)
+			fmt.Printf("curl: %s", string(output))
+			err = utils.CheckStringContainsStrings(string(output), []string{"404 Not Found"})
+			gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred())
 			// End tests
 		})
 	})

--- a/test/e2e/e2e_suite.go
+++ b/test/e2e/e2e_suite.go
@@ -296,8 +296,8 @@ var _ = ginkgo.Describe("controller", ginkgo.Ordered, func() {
 			err = utils.CheckStringContainsStrings(string(output), metricLabels)
 			gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred())
 
-			// verify that 404 HTTP error is being returned for non-existing ingress
-			ginkgo.By("validating default HTTP error code")
+			// verify that default HTTP response code is 404
+			ginkgo.By("validating default HTTP response code")
 			runCmd = fmt.Sprintf(`curl -s -I http://non-existing-domain.%s.nip.io/`, kindIP)
 			output, _ = utils.RunCommonsCommand(namespace, runCmd)
 			fmt.Printf("curl: %s", string(output))


### PR DESCRIPTION
Related issue: https://amazeeio.atlassian.net/browse/PLAT-489

### Changes

- Introduced `default-http-response-code` flag to make the default response status code configurable. The default value is set to `404`.
- Added test case for the change.